### PR TITLE
Update compute_transform.R (lines 54, 55)

### DIFF
--- a/R/compute_transform.R
+++ b/R/compute_transform.R
@@ -51,7 +51,8 @@ compute_transform <- function(x, pre_trained, weighting = 500){
 
   # extract feature frequency from fcm object
   feature_frequency <- x@meta$object$margin
-  feature_frequency <- feature_frequency[intersect(names(feature_frequency), attr(context_embeddings, 'features'))]
+  feature_frequency <- feature_frequency[intersect(names(feature_frequency), rownames(context_embeddings))]
+  feature_frequency <- feature_frequency[intersect(names(feature_frequency), rownames(pre_trained))] # only use overlap btw pretrained and context embeddings (when pretrained embeddings are not trained on local corpus)
   if(weighting == 'log') feature_frequency <- feature_frequency[feature_frequency >= 1] # avoid negatives when taking logs
 
   # apply weighting if given


### PR DESCRIPTION
Hi @prodriguezsosa!

I updated `compute_transform.R` as we discussed to bring it in line with the latest `fem.R` and to ensure checks for overlaps between pre-trained and context embeddings (for when pre-trained embeddings are not trained on the local corpus). 