### PR TITLE
Fixed bug where cos_sim() returned an error when a single feature was…

### DIFF
--- a/R/cos_sim.R
+++ b/R/cos_sim.R
@@ -79,7 +79,7 @@ cos_sim <- function(x, pre_trained, features = NULL, stem = FALSE, language = 'p
   features_present <- features[feature_check]
 
   # subset pre-trained embeddings to features of interest
-  pre_trained_subset <- pre_trained[rownames(pre_trained) %in% features_present,]
+  pre_trained_subset <- pre_trained[rownames(pre_trained) %in% features_present,, drop = FALSE]
 
   # compute cosine similarity
   cos_sim <- text2vec::sim2(as.matrix(x), as.matrix(pre_trained_subset), method = 'cosine', norm = 'l2')


### PR DESCRIPTION
… passed.

cos_sim() returns an error when the vector passed to the features argument is length 1 because subsetting the pre_trained embeddings matrix to a single row produces a 300x1 matrix rather than a 1x300 matrix. This should correct that error so that any number of features produces an _n_ x300 matrix