### PR TITLE
[fix] add missing language parameter for stemming option

### DIFF
--- a/R/get_nns.R
+++ b/R/get_nns.R
@@ -112,6 +112,7 @@ get_nns <- function(x,
                            candidates = candidates,
                            pre_trained = pre_trained,
                            stem = stem,
+                           language = language,
                            as_list = FALSE),
               simplify = FALSE)
     result <- do.call(rbind, nnsdf_bs) %>%
@@ -140,7 +141,7 @@ get_nns <- function(x,
   }
 
   # find nearest neighbors
-  result <- nns(x = wvs, N = N, candidates = candidates, pre_trained = pre_trained, stem = stem, as_list = FALSE, show_language = FALSE)
+  result <- nns(x = wvs, N = N, candidates = candidates, pre_trained = pre_trained, stem = stem, language = language, as_list = FALSE, show_language = FALSE)
   }
 
   # if !as_list return a list object with an item for each target data.frame
@@ -158,6 +159,7 @@ nns_boostrap <- function(x,
                          candidates = character(0),
                          pre_trained,
                          stem = FALSE,
+                         language = language,
                          as_list = FALSE){
 
   # sample dems with replacement
@@ -171,7 +173,7 @@ nns_boostrap <- function(x,
   }
 
   # find nearest neighbors
-  result <- nns(x = wvs, N = Inf, candidates = candidates, pre_trained = pre_trained, stem = stem, as_list = as_list, show_language = FALSE)
+  result <- nns(x = wvs, N = Inf, candidates = candidates, pre_trained = pre_trained, stem = stem, language = language, as_list = as_list, show_language = FALSE)
 
   return(result)
 

--- a/R/nns.R
+++ b/R/nns.R
@@ -66,7 +66,7 @@ nns <- function(x, N = 10, candidates = character(0), pre_trained, stem = FALSE,
   if(stem){
     if (requireNamespace("SnowballC", quietly = TRUE)) {
       if(show_language) cat('Using', language, 'for stemming. To check available languages run "SnowballC::getStemLanguages()"', '\n')
-      pre_trained_feats <- SnowballC::wordStem(rownames(pre_trained))
+      pre_trained_feats <- SnowballC::wordStem(rownames(pre_trained), language = language)
     } else stop('"SnowballC (>= 0.7.0)" package must be installed to use stemmming option.')
   } else pre_trained_feats <- rownames(pre_trained)
 
@@ -75,7 +75,7 @@ nns <- function(x, N = 10, candidates = character(0), pre_trained, stem = FALSE,
 
   # if candidates are provided
   if(length(candidates) > 0) {
-    if(stem) candidates <- SnowballC::wordStem(candidates) # stem
+    if(stem) candidates <- SnowballC::wordStem(candidates, language = language) # stem
 
     # check which, if any candidates, are present
     candidate_check <- candidates %in% pre_trained_feats


### PR DESCRIPTION
I just reran some analyses with the implementation for passing a language argument (https://github.com/prodriguezsosa/conText/issues/17#issuecomment-1428405678) and I think there is an issue. 
tldr: `get_nns` does not pass down the language parameter and inside `nns` the language parameter is not called in `wordStem`. 

The `get_nns` issue can be detected when setting the `nns`-parameter `show_language` to `TRUE`, because it then outputs ("second" line in output) that it's using `porter` to stem. So far, the output message of `get_nns` (only "first" line displayed by default) says that it's using the set language, which is however not the case. These changes should fix the issue.