### PR TITLE
Added ggplot2 transformation support for `plot_nns_ratio`

### DIFF
--- a/man/plot_nns_ratio.Rd
+++ b/man/plot_nns_ratio.Rd
@@ -4,18 +4,21 @@
 \alias{plot_nns_ratio}
 \title{Plot output of \code{get_nns_ratio()}}
 \usage{
-plot_nns_ratio(x, alpha = 0.01, horizontal = TRUE)
+plot_nns_ratio(x, alpha = 0.01, horizontal = TRUE, scale_transform = "identity")
 }
 \arguments{
 \item{x}{output of get_nns_ratio}
 
-\item{alpha}{(numerical) betwee 0 and 1. Significance threshold to identify significant values.
+\item{alpha}{(numerical) between 0 and 1. Significance threshold to identify significant values.
 These are denoted by a \code{*} on the plot.}
 
 \item{horizontal}{(logical) defines the type of plot. if TRUE results are plotted on 1 dimension.
 If FALSE, results are plotted on 2 dimensions, with the second dimension catpuring the ranking
 of cosine ratio similarties.}
 }
+
+\item{scale_transform}{(character) the name of a ggplot2 transformation object or the object itself.
+(see `transform` in ?ggplot2::scale_x_continuous)}
 \value{
 a \code{ggplot-class} object.
 }
@@ -60,6 +63,6 @@ immig_nns_ratio <- get_nns_ratio(x = immig_toks,
                                  num_permutations = 10,
                                  verbose = FALSE)
 
-plot_nns_ratio(x = immig_nns_ratio, alpha = 0.01, horizontal = TRUE)
+plot_nns_ratio(x = immig_nns_ratio, alpha = 0.01, horizontal = FALSE, scale_transform = "log")
 }
 \keyword{plot_nns_ratio}

--- a/vignettes/quickstart.Rmd
+++ b/vignettes/quickstart.Rmd
@@ -336,10 +336,10 @@ immig_nns_ratio <- get_nns_ratio(x = immig_toks,
 head(immig_nns_ratio)
 ```
 
-**conText** also includes a plotting function, `plot_nns_ratio`,  specific to `get_nns_ratio()`, providing a nice visualization of its output. `alpha` defines the desired significance threshold to denote "significant" results on the plot (indicated by a $*$ next to the feature). Also, you can choose between two different visualizations of the same results using the `horizontal` argument.
+**conText** also includes a plotting function, `plot_nns_ratio`,  specific to `get_nns_ratio()`, providing a nice visualization of its output. `alpha` defines the desired significance threshold to denote "significant" results on the plot (indicated by a $*$ next to the feature). Also, you can choose between two different visualizations of the same results using the `horizontal` argument. Finally, you can specify a ggplot2 transformation with the `scale_transform` argument.
 
 ```{r, eval=TRUE}
-plot_nns_ratio(x = immig_nns_ratio, alpha = 0.01, horizontal = TRUE)
+plot_nns_ratio(x = immig_nns_ratio, alpha = 0.01, horizontal = FALSE, scale_transform = "log")
 ```
 
 ### Nearest contexts

--- a/vignettes/quickstart.md
+++ b/vignettes/quickstart.md
@@ -653,7 +653,7 @@ feature). Also, you can choose between two different visualizations of
 the same results using the `horizontal` argument.
 
 ``` r
-plot_nns_ratio(x = immig_nns_ratio, alpha = 0.01, horizontal = TRUE)
+plot_nns_ratio(x = immig_nns_ratio, alpha = 0.01, horizontal = FALSE, scale_transform = "log")
 ```
 
 ![](/private/var/folders/3g/g_rcryn50tjfk4j52hz39hm40000gn/T/RtmpXpaJgy/preview-14d46569abbaf.dir/quickstart_files/figure-gfm/unnamed-chunk-21-1.png)<!-- -->


### PR DESCRIPTION
Dear authors,

In submitting this pull request, I added a new argument called `scale_transform` to `plot_nns_ratio`, which specifies the [ggplot2 transformation](https://ggplot2.tidyverse.org/reference/scale_continuous.html) of the x axis. I tested the changes with the following code (largely based on `example(plot_nns_ratio)`):

<details><summary>Example (click to expand)</summary>

```r
library(ggplot2)
library(quanteda)
library(conText)

# tokenize corpus
toks <- tokens(cr_sample_corpus)

# build a tokenized corpus of contexts sorrounding a target term
immig_toks <- tokens_context(x = toks, pattern = "immigration", window = 6L)

# sample 100 instances of the target term, stratifying by party (only for example purposes)
set.seed(2022L)
immig_toks <- tokens_sample(immig_toks, size = 100, by = docvars(immig_toks, 'party'))

# we limit candidates to features in our corpus
feats <- featnames(dfm(immig_toks))

# compute ratio
set.seed(2022L)
immig_nns_ratio <- get_nns_ratio(x = immig_toks,
                                 N = 10,
                                 groups = docvars(immig_toks, 'party'),
                                 numerator = "R",
                                 candidates = feats,
                                 pre_trained = cr_glove_subset,
                                 transform = TRUE,
                                 transform_matrix = cr_transform,
                                 bootstrap = TRUE,
                                 # num_bootstraps should be at least 100,
                                 # we use 10 here due to CRAN-imposed constraints
                                 # on example execution time
                                 num_bootstraps = 100,
                                 permute = FALSE,
                                 num_permutations = 10,
                                 verbose = FALSE)

plot_nns_ratio(x = immig_nns_ratio, alpha = 0.01, horizontal = FALSE, scale_transform = "identity")
ggsave("vertical-identity.png")
plot_nns_ratio(x = immig_nns_ratio, alpha = 0.01, horizontal = TRUE, scale_transform = "identity")
ggsave("horizontal-identity.png")
plot_nns_ratio(x = immig_nns_ratio, alpha = 0.01, horizontal = FALSE, scale_transform = "log")
ggsave("vertical-log.png")
plot_nns_ratio(x = immig_nns_ratio, alpha = 0.01, horizontal = TRUE, scale_transform = "log")
ggsave("horizontal-log.png")
```
</details>

Here are the resulting plots

| `scale_transform` | `horizonal=TRUE` | `horizonal=FALSE` |
| ------------- | ------------- | ------------- |
| `"identity"` | <img src="https://github.com/user-attachments/assets/c1b23f68-16f1-431d-9756-98e2c7d8285a" alt="horizontal-identity" width="400" height="300"> | <img src="https://github.com/user-attachments/assets/af3c6bdb-e249-427e-bb9c-75fbbba25135" alt="vertical-identity" width="400" height="300">  |
| `"log"` | <img src="https://github.com/user-attachments/assets/b54e04ed-8ba2-4f1f-bb2f-153b3a396436" alt="horizontal-log" width="400" height="300"> | <img src="https://github.com/user-attachments/assets/a260a017-19c0-4fa7-894c-d7578b139ee9" alt="vertial-log" width="400" height="300"> |

This is just a basic implementation. Let me know if you want me to make any further changes!